### PR TITLE
fix: preview envs pipelines fixes

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-hugomod-
 
       - name: Build
-        run: just build-prod
+        run: just build-web
 
       - name: Archive built web
         uses: actions/upload-artifact@v4

--- a/.github/workflows/preview_env.yaml
+++ b/.github/workflows/preview_env.yaml
@@ -106,7 +106,6 @@ jobs:
 
   destroy:
     if: github.event.action == 'closed'
-    needs: build
     runs-on: ubuntu-latest
     env:
       APP_ENV: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Fixes wrong just task in production web build and removes dependency for preview env destroying on build tasks - this would skip destroy and leave the PR environment deployed.